### PR TITLE
Move i-should-run-after-ember-data to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test"
   },
+  "dependencies": {
+    "i-should-run-after-ember-data": "link:./lib/i-should-run-after-ember-data"
+  },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@embroider/compat": "^1.2.0",
@@ -61,9 +64,4 @@
   "ember": {
     "edition": "octane"
   },
-  "ember-addon": {
-    "paths": [
-      "lib/i-should-run-after-ember-data"    
-    ]
-  }
 }


### PR DESCRIPTION
This PR is incomplete, you will still need to run `yarn` (to ensure the `yarn.lock` is updated). Just trying to show what it might look like as a dependency vs devDependency.